### PR TITLE
Add specific version when installing cura

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM ubuntu:xenial
+FROM ubuntu:bionic
 
 RUN apt-get -y update && \
     apt-get -y install software-properties-common && \
     add-apt-repository ppa:thopiekar/cura && \
     apt-get -y update && \
-    apt-get -y install cura
+    apt-get -y install cura=1:3.3.1~201806260857~rev3015~pkg252~ubuntu18.04.1
 
 CMD /usr/bin/cura


### PR DESCRIPTION
Installing a specific version and using docker tags with cura version allows the docker image users to get a specific version of cura.

Fixes #1 